### PR TITLE
Modernize pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
         </dependency>
     </dependencies>
     <build>
-        <sourceDirectory>${basedir}/src/main/java/</sourceDirectory>
+        <sourceDirectory>${project.basedir}/src/main/java/</sourceDirectory>
         <resources>
             <resource>
                 <targetPath>.</targetPath>
                 <filtering>true</filtering>
-                <directory>${basedir}/src/main/resources/</directory>
+                <directory>${project.basedir}/src/main/resources/</directory>
             </resource>
         </resources>
         <plugins>


### PR DESCRIPTION
{basedir} is now deprecated in the newer versions of Maven, the modern version is {project.basedir}
