### PR TITLE
Implement Setting GUI

### DIFF
--- a/src/main/java/me/anxuiz/settings/bukkit/BukkitSettingRegistry.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/BukkitSettingRegistry.java
@@ -1,0 +1,80 @@
+package me.anxuiz.settings.bukkit;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Maps;
+import me.anxuiz.settings.Setting;
+import me.anxuiz.settings.SettingRegistry;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nullable;
+
+public class BukkitSettingRegistry implements SettingRegistry {
+    protected final Map<Setting, ItemStack> settings = Maps.newLinkedHashMap();
+
+    public Setting get(String search, boolean includeAliases) {
+        Preconditions.checkNotNull(search);
+
+        for(Setting setting : this.settings.keySet()) {
+            if(setting.getName().equalsIgnoreCase(search)) {
+                return setting;
+            }
+        }
+
+        // look through aliases afterward so the name match can be found first
+        if(includeAliases) {
+            for(Setting setting : this.settings.keySet()) {
+                for(String alias : setting.getAliases()) {
+                    if(alias.equalsIgnoreCase(search)) {
+                        return setting;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public Setting find(String search, boolean includeAliases) throws IllegalArgumentException {
+        Setting setting = this.get(search, includeAliases);
+        if(setting != null) {
+            return setting;
+        } else {
+            throw new IllegalArgumentException("failed to find setting for '" + search + "'");
+        }
+    }
+
+    public Set<Setting> getSettings() {
+        return ImmutableSet.copyOf(this.settings.keySet());
+    }
+
+    public boolean isRegistered(Setting setting) {
+        Preconditions.checkNotNull(setting);
+
+        return this.settings.keySet().contains(setting);
+    }
+
+    public void register(Setting setting) {
+        this.register(setting, null);
+    }
+
+    public void register(Setting setting, @Nullable ItemStack icon) throws IllegalArgumentException {
+        Preconditions.checkNotNull(setting);
+        Preconditions.checkArgument(this.get(setting.getName(), false) == null, "setting already registered to name '%s'", setting.getName());
+
+        this.settings.put(setting, icon);
+    }
+
+    public boolean unregister(Setting setting) {
+        this.settings.remove(setting);
+        return this.settings.containsKey(setting);
+    }
+
+    public ItemStack getIcon(Setting setting) {
+        return this.settings.get(setting);
+    }
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/PlayerSettings.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/PlayerSettings.java
@@ -4,9 +4,7 @@ import javax.annotation.Nonnull;
 
 import me.anxuiz.settings.SettingCallbackManager;
 import me.anxuiz.settings.SettingManager;
-import me.anxuiz.settings.SettingRegistry;
 import me.anxuiz.settings.base.SimpleSettingCallbackManager;
-import me.anxuiz.settings.base.SimpleSettingRegistry;
 import me.anxuiz.settings.bukkit.plugin.BukkitSettingsPlugin;
 
 import org.bukkit.entity.Player;
@@ -14,10 +12,11 @@ import org.bukkit.entity.Player;
 import com.google.common.base.Preconditions;
 
 public class PlayerSettings {
-    private static final SettingRegistry registry = new SimpleSettingRegistry();
+    private static final BukkitSettingRegistry registry = new BukkitSettingRegistry();
     private static final SimpleSettingCallbackManager callbackManager = new SimpleSettingCallbackManager();
 
-    public static @Nonnull SettingRegistry getRegistry() {
+    public static @Nonnull
+    BukkitSettingRegistry getRegistry() {
         return registry;
     }
 

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/Clickable.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/Clickable.java
@@ -1,0 +1,57 @@
+package me.anxuiz.settings.bukkit.plugin.gui;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+public abstract class Clickable implements Listener {
+
+    private ItemStack itemStack;
+    private Inventory inventory;
+
+    public Clickable(ItemStack itemStack, Inventory inventory) {
+        this.itemStack = itemStack;
+        this.inventory = inventory;
+        this.register();
+    }
+
+    public ItemStack getItemStack() {
+        return this.itemStack;
+    }
+
+    public void setItemStack(ItemStack itemStack) {
+        this.itemStack = itemStack;
+    }
+
+    public Inventory getInventory() {
+        return this.inventory;
+    }
+
+    public void unregister() {
+        InventoryManager.getListenerRegistry().unregisterListener(this, this.inventory);
+    }
+
+    public void register() {
+        InventoryManager.getListenerRegistry().registerListener(this, this.inventory);
+    }
+
+    public abstract void click(InventoryClickEvent event);
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (event.getInventory().equals(this.inventory) && event.getCurrentItem() != null && event.getCurrentItem().equals(this.itemStack)) {
+            click(event);
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (event.getInventory().equals(this.inventory)) {
+            this.unregister();
+        }
+    }
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/InventoryManager.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/InventoryManager.java
@@ -1,0 +1,15 @@
+package me.anxuiz.settings.bukkit.plugin.gui;
+
+import me.anxuiz.settings.bukkit.plugin.BukkitSettingsPlugin;
+
+import javax.annotation.Nonnull;
+
+public class InventoryManager {
+
+    private static final ListenerRegistry listenerRegistry = new ListenerRegistry(BukkitSettingsPlugin.get());
+
+    public static @Nonnull ListenerRegistry getListenerRegistry() {
+        return listenerRegistry;
+    }
+
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/ItemBuilder.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/ItemBuilder.java
@@ -1,0 +1,95 @@
+package me.anxuiz.settings.bukkit.plugin.gui;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class ItemBuilder {
+
+    private ItemStack itemStack;
+    private Material material;
+    private int amount = 1;
+    private short damage = 0;
+    private String name;
+    private List<String> lore = Lists.newArrayList();
+    private Map<Enchantment, Integer> enchantments = Maps.newHashMap();
+
+    public ItemBuilder(Material material) {
+        this.material = material;
+    }
+
+    public ItemBuilder(ItemStack itemStack) {
+        this.itemStack = itemStack;
+    }
+
+    public ItemBuilder setMaterial(Material material) {
+        this.material = material;
+        return this;
+    }
+
+    public ItemBuilder setDamage(short damage) {
+        this.damage = damage;
+        return this;
+    }
+
+    public ItemBuilder setAmount(int amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public ItemBuilder setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public ItemBuilder setLore(List<String> lore) {
+        this.lore = lore;
+        return this;
+    }
+
+    public ItemBuilder addLore(String lore) {
+        this.lore.add(lore);
+        return this;
+    }
+
+    public ItemBuilder addLore(String... lore) {
+        for (String string : lore)
+            this.lore.add(string);
+        return this;
+    }
+
+    public ItemBuilder setEnchantments(Map<Enchantment, Integer> enchantments) {
+        this.enchantments = enchantments;
+        return this;
+    }
+
+    public ItemBuilder addEnchantment(Enchantment enchantment, int value) {
+        this.enchantments.put(enchantment, value);
+        return this;
+    }
+
+    public ItemStack createItem() {
+        if (itemStack == null)
+            this.itemStack = new ItemStack(this.material, this.amount, this.damage);
+        ItemMeta itemMeta = this.itemStack.getItemMeta();
+        if (this.name != null)
+            itemMeta.setDisplayName(this.name);
+        if (this.lore != null)
+            itemMeta.setLore(this.lore);
+        if (this.enchantments != null) {
+            for (Enchantment enchantment : this.enchantments.keySet()) {
+                itemMeta.addEnchant(enchantment, this.enchantments.get(enchantment), true);
+            }
+        }
+        this.itemStack.setItemMeta(itemMeta);
+        return this.itemStack;
+    }
+
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/ListenerRegistry.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/ListenerRegistry.java
@@ -1,0 +1,61 @@
+package me.anxuiz.settings.bukkit.plugin.gui;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import me.anxuiz.settings.bukkit.plugin.BukkitSettingsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.plugin.PluginManager;
+
+import java.util.Map;
+import java.util.Set;
+
+public class ListenerRegistry {
+
+    private final BukkitSettingsPlugin plugin;
+    private final PluginManager pluginManager;
+
+    private final Map<Inventory, Set<Listener>> listeners;
+
+    public ListenerRegistry(BukkitSettingsPlugin plugin) {
+        this.plugin = plugin;
+        this.pluginManager = Bukkit.getPluginManager();
+        this.listeners = Maps.newLinkedHashMap();
+        this.cleanListeners();
+    }
+
+    public void registerListener(Listener listener, Inventory inventory) {
+        Preconditions.checkNotNull(listener);
+        Preconditions.checkNotNull(inventory);
+        Set<Listener> values = Sets.newHashSet();
+        if (this.listeners.containsKey(inventory))
+            values = this.listeners.get(inventory);
+        values.add(listener);
+        this.listeners.put(inventory, values);
+        this.pluginManager.registerListener(this.plugin, listener);
+    }
+
+    public void unregisterListener(Listener listener, Inventory inventory) {
+        Preconditions.checkNotNull(listener);
+        Preconditions.checkNotNull(inventory);
+        this.listeners.get(inventory).remove(listener);
+        this.pluginManager.unregisterListener(listener);
+    }
+
+    private void cleanListeners() {
+        Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(this.plugin, new Runnable() {
+            public void run() {
+                for (Map.Entry<Inventory, Set<Listener>> map : listeners.entrySet()) {
+                    if (!(map.getKey().getViewers().size() > 0)) {
+                        for (Listener listener : map.getValue()) {
+                            unregisterListener(listener, map.getKey());
+                        }
+                    }
+                }
+            }
+        }, 0L, 20L * 60); // Repeats every minute
+    }
+
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/SettingsMenuBuilder.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/SettingsMenuBuilder.java
@@ -1,0 +1,102 @@
+package me.anxuiz.settings.bukkit.plugin.gui;
+
+import com.google.common.collect.Sets;
+import me.anxuiz.settings.Setting;
+import me.anxuiz.settings.SettingManager;
+import me.anxuiz.settings.Toggleable;
+import me.anxuiz.settings.bukkit.PlayerSettings;
+import me.anxuiz.settings.bukkit.plugin.Commands;
+import me.anxuiz.settings.bukkit.plugin.Permissions;
+import me.anxuiz.settings.bukkit.plugin.SettingsCommand;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Set;
+
+public class SettingsMenuBuilder {
+
+    private static final Set<Setting> settings = Sets.newLinkedHashSet(PlayerSettings.getRegistry().getSettings());
+
+    private static final ItemStack BORDER_ICON = new ItemBuilder(Material.STAINED_GLASS_PANE).setDamage((short) 7).setName(ChatColor.GRAY + "#").createItem();
+
+    private static Inventory makeInventory() {
+        int size = settings.size();
+        int slots = (int) ((Math.round((size / 7) + 0.5) + 2) * 9);
+        return makeBorder(Bukkit.createInventory(null, slots, "Customize Your Settings!"));
+
+    }
+
+    /**
+     *                      INVENTORY
+     *
+     * Based on vector i and j notation.
+     * 0i through 8i horizontally
+     * 1j through <code>n</code>j vertically, where <code>n</code> is number of rows
+     *
+     */
+    private static Inventory makeBorder(Inventory inventory) {
+        int k = 0;
+        for (int j = 1; j <= inventory.getSize() / 9; j++) {
+            for (int i = 0; i < 9; i++) {
+                if (i == 0 || i == 8 || j == 1 || j == inventory.getSize() / 9)
+                    inventory.setItem(k, BORDER_ICON);
+                k++;
+            }
+        }
+        // Create single click handler for all border items
+        new Clickable(BORDER_ICON, inventory) {
+            @Override
+            public void click(InventoryClickEvent event) {
+                if (!event.isCancelled())
+                    event.setCancelled(true);
+            }
+        };
+        return inventory;
+    }
+
+    private static Inventory populateSettings(Inventory inventory, Player player) {
+        for (Setting setting : SettingsCommand.getSortedPlayerSettings(player)) {
+            inventory.addItem(makeIcon(setting, player, inventory));
+        }
+        return inventory;
+    }
+
+    private static ItemStack makeIcon(final Setting setting, final Player player, final Inventory inventory) {
+         ItemStack icon = new ItemBuilder(PlayerSettings.getRegistry().getIcon(setting))
+                .setName(ChatColor.YELLOW + setting.getName())
+                .addLore(ChatColor.GREEN + "Current Value: " + ChatColor.RESET + setting.getType().print(PlayerSettings.getManager(player).getValue(setting)))
+                .addLore(ChatColor.AQUA + "Default Value: " + ChatColor.RESET + setting.getType().print(setting.getDefaultValue()))
+                .addLore(ChatColor.YELLOW + "Summary: " + ChatColor.RESET + setting.getSummary())
+                .addLore(ChatColor.RED + "" + ChatColor.BOLD + setting.getDescription())
+                .addLore(ChatColor.YELLOW + "" + ChatColor.ITALIC + "Click to cycle values!")
+                .createItem();
+        // Each item has its own click handler:
+        return new Clickable(icon, inventory) {
+            @Override
+            public void click(InventoryClickEvent event) {
+                Player player = event.getActor();
+                if (Permissions.hasViewPermission(player, setting) && Permissions.hasSetPermission(player, setting)) {
+                    // Update setting
+                    SettingManager manager = PlayerSettings.getManager(player);
+                    manager.setValue(setting, setting.getType() instanceof Toggleable ? ((Toggleable) setting.getType()).getNextState(manager.getValue(setting)) : manager.getValue(setting));
+                    Commands.sendSettingValue(player, manager, setting);
+                    // Add item to inventory
+                    event.getInventory().setItem(event.getSlot(), makeIcon(setting, player, inventory));
+                    player.playSound(player.getLocation(), Sound.BLOCK_LEVER_CLICK, 1, 1);
+                    // Unregister old listener ready for new item listener
+                    this.unregister();
+                } else player.sendMessage(Commands.NO_PERMISSION);
+            }
+        }.getItemStack();
+    }
+
+    public static Inventory build(Player player) {
+        return populateSettings(makeInventory(), player);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,8 +14,8 @@ commands:
     usage: /<command> <setting name>
     description: View information about a specified setting
   settings:
-    usage: /<command> [page]
-    description: List registered settings
+    usage: /<command> [list] [page]
+    description: Open a menu to view and edit all settings or simply list all settings
   toggle:
     usage: /<command> <setting name>
     description: Toggles a specified setting if it is toggleable


### PR DESCRIPTION
A requested feature by many inside the staff.

This implementation removes the base `SimpleSettingRegistry` from the `Setting` library and moves it down into this plugin inside `BukkitSettingRegistry` in order to include Bukkit API specific objects.

The registry now holds a map of settings being paired with an `ItemStack` to give it an icon when using a GUI. This means that when registering a setting you also have to pass in an `ItemStack`. I designed it this way to keep the abstraction of the `Setting` class and interface in the library, otherwise it would have somehow had to been pulled down into this plugin and re factored to allow for `ItemStack` object to be present from the Bukkit API.

I also designed it so that the `SettingsMenuBuilder` used all static methods, this is so a new instance of  the menu class isn't unnecessarily made  each time a player opens the inventory.

I've also packed an `ItemStack` builder into the plugin to make it easy when manipulating and adding icons for the GUI.

Finally I'll explain how the menu building process works.
The first thing to note is that the menu will only display settings of type `Toggleable` due to this being the only thing a player can edit within a GUI.
The GUI also has the option of a border using a specified item, used by default, this works by mapping the inventory using vector **i** and **j**  notation, or coordinates if you prefer, however `i` and `j` are used for rows and columns inside the code, as that's how I've liked to think about them

An image of the GUI
![](http://i.imgur.com/0zkI97p.png)

The original output of the command has been moved to `/settings list [page]`

I'll make a PR for the` Settings` repo changes in the morning if this is accepted .

Thanks