### PR TITLE
Implement Settings GUI

### DIFF
--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/BukkitSetting.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/BukkitSetting.java
@@ -1,0 +1,28 @@
+package me.anxuiz.settings.bukkit.plugin;
+
+import me.anxuiz.settings.Type;
+import me.anxuiz.settings.base.SimpleSetting;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Set;
+
+public class BukkitSetting extends SimpleSetting {
+
+    private @Nullable ItemStack icon;
+
+    public BukkitSetting(@Nonnull String name, @Nonnull Set<String> aliases, @Nonnull String summary, @Nullable String description, @Nonnull Type type, @Nullable Object defaultValue, @Nullable ItemStack icon) {
+        super(name, aliases, summary, description, type, defaultValue);
+        this.icon = icon;
+    }
+
+
+    public @Nullable ItemStack getIcon() {
+        return this.icon;
+    }
+
+    public void setIcon(@Nullable ItemStack icon) {
+        this.icon = icon;
+    }
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/SettingsCommand.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/SettingsCommand.java
@@ -8,12 +8,19 @@ import java.util.List;
 import me.anxuiz.settings.Setting;
 import me.anxuiz.settings.bukkit.PlayerSettings;
 
+import me.anxuiz.settings.bukkit.plugin.gui.MenuBuilder;
+import me.anxuiz.settings.bukkit.plugin.gui.base.clear.NoBorderFactory;
+import me.anxuiz.settings.bukkit.plugin.gui.base.clear.NoBorderStyle;
+import me.anxuiz.settings.bukkit.plugin.gui.base.simple.SimpleBorderFactory;
+import me.anxuiz.settings.bukkit.plugin.gui.base.simple.SimpleBorderStyle;
+import me.anxuiz.settings.bukkit.plugin.gui.base.simple.SimpleInventoryFactory;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 
 import com.google.common.collect.Lists;
+import org.bukkit.entity.Player;
 
 public class SettingsCommand implements CommandExecutor {
     public static int RESULTS_PER_PAGE = 8;
@@ -24,29 +31,35 @@ public class SettingsCommand implements CommandExecutor {
             return true;
         }
 
-        List<Setting> settings = getSortedPlayerSettings(sender);
+        if (!(args.length > 0)) {
+            if (sender instanceof Player) {
+                ((Player) sender).openInventory(MenuBuilder.buildSettingsMenu(new SimpleBorderFactory().createStyle(), new SimpleInventoryFactory().createStyle((Player) sender)));
+            }
+        } else {
 
-        int maxPage = (settings.size() - 1) / RESULTS_PER_PAGE + 1;
+            List<Setting> settings = getSortedPlayerSettings(sender);
 
-        int page = 1;
-        if(args.length > 0) {
-            try {
-                page = Integer.parseInt(args[0]);
-            } catch (NumberFormatException e) {
-                sender.sendMessage(ChatColor.RED + "Unable to parse page number");
-                return true;
+            int maxPage = (settings.size() - 1) / RESULTS_PER_PAGE + 1;
+
+            int page = 1;
+            if (args.length > 1) {
+                try {
+                    page = Integer.parseInt(args[1]);
+                } catch (NumberFormatException e) {
+                    sender.sendMessage(ChatColor.RED + "Unable to parse page number");
+                    return true;
+                }
+            }
+            page = Math.min(maxPage, Math.max(page, 1)); // constrain page to valid number
+
+            String title = ChatColor.YELLOW + "Settings (Page " + page + " of " + maxPage + ")";
+            sender.sendMessage(Commands.formatHeader(title));
+
+            for (int i = RESULTS_PER_PAGE * (page - 1); i < RESULTS_PER_PAGE * page && i < settings.size(); i++) {
+                Setting setting = settings.get(i);
+                sender.sendMessage(ChatColor.YELLOW + setting.getName() + ": " + ChatColor.RESET + setting.getSummary());
             }
         }
-        page = Math.min(maxPage, Math.max(page, 1)); // constrain page to valid number
-
-        String title = ChatColor.YELLOW + "Settings (Page " + page + " of " + maxPage + ")";
-        sender.sendMessage(Commands.formatHeader(title));
-
-        for(int i = RESULTS_PER_PAGE * (page - 1); i < RESULTS_PER_PAGE * page && i < settings.size(); i++) {
-            Setting setting = settings.get(i);
-            sender.sendMessage(ChatColor.YELLOW + setting.getName() + ": " + ChatColor.RESET + setting.getSummary());
-        }
-
         return true;
     }
 

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/BorderStyle.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/BorderStyle.java
@@ -1,0 +1,40 @@
+package me.anxuiz.settings.bukkit.plugin.gui;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Set;
+
+public interface BorderStyle {
+
+    /**
+     * Define where to put the top border items in <code>inventory</code>
+     * @param inventory That the items are be put in to
+     */
+    void populateTop(Inventory inventory);
+
+    /**
+     * Define where to put the bottom border items in <code>inventory</code>
+     * @param inventory That the items are be put in to
+     */
+    void populateBottom(Inventory inventory);
+
+    /**
+     * Define where to put the left border items in <code>inventory</code>
+     * @param inventory That the items are be put in to
+     */
+    void populateLeft(Inventory inventory);
+
+    /**
+     * Define where to put the right border items in <code>inventory</code>
+     * @param inventory That the items are be put in to
+     */
+    void populateRight(Inventory inventory);
+
+    /**
+     * A set of all {@link ItemStack} that are used for the border
+     * @return
+     */
+    Set<ItemStack> getBoarderIcons();
+
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/Clickable.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/Clickable.java
@@ -1,0 +1,87 @@
+package me.anxuiz.settings.bukkit.plugin.gui;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+public abstract class Clickable implements Listener {
+
+    private List<ItemStack> itemStack;
+    private Inventory inventory;
+
+    /**
+     * Creates a wrapped class for item listeners that is inventory specific
+     * @param inventory Inventory the listener will belong to
+     * @param itemStack a {@link List} of {@link ItemStack} that the listener looks for
+     */
+    public Clickable(Inventory inventory, List<ItemStack> itemStack) {
+        this.itemStack = itemStack;
+        this.inventory = inventory;
+        this.register();
+    }
+
+    /**
+     * @return A {@link List} of {@link ItemStack} that the listener looks for
+     */
+    public List<ItemStack> getItemStacks() {
+        return this.itemStack;
+    }
+
+    /**
+     * Set the {@link List} of {@link ItemStack}
+     * @param itemStack list to set
+     */
+    public void setItemStack(List<ItemStack> itemStack) {
+        this.itemStack = itemStack;
+    }
+
+    /**
+     * @return {@link Inventory} that this listener will be looking in
+     */
+    public Inventory getInventory() {
+        return this.inventory;
+    }
+
+    /**
+     * Unregisters this {@link Clickable} using {@link ListenerRegistry#unregisterListener(Listener, Inventory)} method
+     */
+    public void unregister() {
+        InventoryManager.getListenerRegistry().unregisterListener(this, this.inventory);
+    }
+
+    /**
+     * Registers this {@link Clickable} using {@link ListenerRegistry#registerListener(Listener, Inventory)} method
+     */
+    public void register() {
+        InventoryManager.getListenerRegistry().registerListener(this, this.inventory);
+    }
+
+    /**
+     * An abstract method that is created as an anonymous class to define what happens when one of the border items is clickd
+     * @param event {@link InventoryClickEvent}
+     */
+    public abstract void click(InventoryClickEvent event);
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (event.getInventory().equals(this.inventory) && event.getCurrentItem() != null && this.itemStack.contains(event.getCurrentItem())) {
+            click(event);
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (event.getInventory().equals(this.inventory)) {
+            this.unregister();
+        }
+    }
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/InventoryManager.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/InventoryManager.java
@@ -1,0 +1,15 @@
+package me.anxuiz.settings.bukkit.plugin.gui;
+
+import me.anxuiz.settings.bukkit.plugin.BukkitSettingsPlugin;
+
+import javax.annotation.Nonnull;
+
+public class InventoryManager {
+
+    private static final ListenerRegistry listenerRegistry = new ListenerRegistry(BukkitSettingsPlugin.get());
+
+    public static @Nonnull ListenerRegistry getListenerRegistry() {
+        return listenerRegistry;
+    }
+
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/InventoryStyle.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/InventoryStyle.java
@@ -1,0 +1,13 @@
+package me.anxuiz.settings.bukkit.plugin.gui;
+
+import org.bukkit.inventory.Inventory;
+
+public interface InventoryStyle {
+
+    /**
+     * A method to set where the settings will be placed
+     * @param inventory where the settngs are being placed
+     */
+    void populateSlots(Inventory inventory);
+
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/ListenerRegistry.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/ListenerRegistry.java
@@ -1,0 +1,80 @@
+package me.anxuiz.settings.bukkit.plugin.gui;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import me.anxuiz.settings.bukkit.plugin.BukkitSettingsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.Map;
+import java.util.Set;
+
+public class ListenerRegistry {
+
+
+
+    private final BukkitSettingsPlugin plugin;
+    private final PluginManager pluginManager;
+
+    private final Map<Inventory, Set<Listener>> listeners;
+
+    public ListenerRegistry(BukkitSettingsPlugin plugin) {
+        this.plugin = plugin;
+        this.pluginManager = Bukkit.getPluginManager();
+        this.listeners = Maps.newLinkedHashMap();
+        this.cleanListeners();
+    }
+
+    /**
+     * This will register a listener to an inventory, as an inventory can have multiple listeners for individual item handling
+     * @param listener {@link Listener} that is being registered to <code>inventory</code>
+     * @param inventory {@link Inventory} that is having <code>listener</code> being registered to it
+     */
+    public void registerListener(Listener listener, Inventory inventory) {
+        Preconditions.checkNotNull(listener);
+        Preconditions.checkNotNull(inventory);
+        Set<Listener> values = Sets.newHashSet();
+        if (this.listeners.containsKey(inventory))
+            values = this.listeners.get(inventory);
+        values.add(listener);
+        this.listeners.put(inventory, values);
+        this.pluginManager.registerListener(this.plugin, listener);
+    }
+
+    /**
+     * This will unregister a listener that is assigned to an inventory
+     * @param listener {@link Listener} that is being unregistered from <code>inventory</code>
+     * @param inventory {@link Inventory} that is having <code>listener</code> being unregistered from it
+     */
+    public void unregisterListener(Listener listener, Inventory inventory) {
+        Preconditions.checkNotNull(listener);
+        Preconditions.checkNotNull(inventory);
+        this.pluginManager.unregisterListener(listener);
+        this.listeners.get(inventory).remove(listener);
+        if (this.listeners.get(inventory).size() == 0) this.listeners.remove(inventory);
+    }
+
+    /**
+     * This method is run every hour to ensure that no listeners are left and not disposed of, this is a safety measure that shouldn't be necessary
+     */
+    private void cleanListeners() {
+        Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(this.plugin, new Runnable() {
+            public void run() {
+                for (Map.Entry<Inventory, Set<Listener>> map : listeners.entrySet()) {
+                    if (!(map.getKey().getViewers().size() > 0)) {
+                        for (Listener listener : map.getValue()) {
+                            Bukkit.broadcastMessage("unregister");
+                        }
+                    }
+                }
+            }
+        }, 0L, 20L * 3600); // Repeats every hour
+    }
+
+
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/MenuBuilder.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/MenuBuilder.java
@@ -1,0 +1,56 @@
+package me.anxuiz.settings.bukkit.plugin.gui;
+
+import com.google.common.collect.Sets;
+import me.anxuiz.settings.Setting;
+import me.anxuiz.settings.bukkit.PlayerSettings;
+import org.bukkit.Bukkit;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class MenuBuilder {
+
+    private static final Set<Setting> settings = Sets.newLinkedHashSet(PlayerSettings.getRegistry().getSettings());
+
+    private MenuBuilder() {}
+
+    /**
+     * Creates an customised {@link Inventory}
+     * @param borderStyle this is a custom defined way the border is presented
+     * @param inventoryStyle this is a custom defined way the settings inside the inventory are presented
+     * @return the {@link Inventory} that is created
+     */
+    public static Inventory buildSettingsMenu(BorderStyle borderStyle, InventoryStyle inventoryStyle) {
+        int slots = (int) ((Math.round((settings.size() / (borderStyle.getBoarderIcons() != null ? 7 : 9) + 0.5)) + (borderStyle.getBoarderIcons() != null ? 2 : 0)) * 9);
+        Inventory inventory = Bukkit.createInventory(null, slots, "Customize Your Settings!");
+
+        borderStyle.populateTop(inventory);
+        borderStyle.populateLeft(inventory);
+        borderStyle.populateRight(inventory);
+        borderStyle.populateBottom(inventory);
+
+        inventoryStyle.populateSlots(inventory);
+
+        if (borderStyle.getBoarderIcons() != null) {
+            List<ItemStack> boarders = new ArrayList<ItemStack>(borderStyle.getBoarderIcons());
+
+            new Clickable(inventory, boarders) {
+                @Override
+                public void click(InventoryClickEvent event) {
+                    if (!event.isCancelled())
+                        event.setCancelled(true);
+                }
+            };
+        }
+
+        return inventory;
+    }
+
+
+
+
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/clear/NoBorderFactory.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/clear/NoBorderFactory.java
@@ -1,0 +1,11 @@
+package me.anxuiz.settings.bukkit.plugin.gui.base.clear;
+
+import me.anxuiz.settings.bukkit.plugin.gui.BorderStyle;
+import me.anxuiz.settings.bukkit.plugin.gui.base.factory.BorderStyleFactory;
+
+public class NoBorderFactory implements BorderStyleFactory {
+
+    public BorderStyle createStyle() {
+        return new NoBorderStyle();
+    }
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/clear/NoBorderStyle.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/clear/NoBorderStyle.java
@@ -1,0 +1,33 @@
+package me.anxuiz.settings.bukkit.plugin.gui.base.clear;
+
+import me.anxuiz.settings.bukkit.plugin.gui.BorderStyle;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Set;
+
+/**
+ * A {@link BorderStyle} that has no border
+ */
+public class NoBorderStyle implements BorderStyle {
+
+    public void populateTop(Inventory inventory) {
+
+    }
+
+    public void populateBottom(Inventory inventory) {
+
+    }
+
+    public void populateLeft(Inventory inventory) {
+
+    }
+
+    public void populateRight(Inventory inventory) {
+
+    }
+
+    public Set<ItemStack> getBoarderIcons() {
+        return null;
+    }
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/factory/BorderStyleFactory.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/factory/BorderStyleFactory.java
@@ -1,0 +1,9 @@
+package me.anxuiz.settings.bukkit.plugin.gui.base.factory;
+
+import me.anxuiz.settings.bukkit.plugin.gui.BorderStyle;
+
+public interface BorderStyleFactory {
+
+    BorderStyle createStyle();
+
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/factory/InventoryStyleFactory.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/factory/InventoryStyleFactory.java
@@ -1,0 +1,10 @@
+package me.anxuiz.settings.bukkit.plugin.gui.base.factory;
+
+import me.anxuiz.settings.bukkit.plugin.gui.InventoryStyle;
+import org.bukkit.entity.Player;
+
+public interface InventoryStyleFactory {
+
+    InventoryStyle createStyle(Player player);
+
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/simple/SimpleBorderFactory.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/simple/SimpleBorderFactory.java
@@ -1,0 +1,11 @@
+package me.anxuiz.settings.bukkit.plugin.gui.base.simple;
+
+import me.anxuiz.settings.bukkit.plugin.gui.BorderStyle;
+import me.anxuiz.settings.bukkit.plugin.gui.base.factory.BorderStyleFactory;
+
+public class SimpleBorderFactory implements BorderStyleFactory {
+
+    public BorderStyle createStyle() {
+        return new SimpleBorderStyle();
+    }
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/simple/SimpleBorderStyle.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/simple/SimpleBorderStyle.java
@@ -1,0 +1,62 @@
+package me.anxuiz.settings.bukkit.plugin.gui.base.simple;
+
+import com.google.common.collect.Sets;
+import me.anxuiz.settings.bukkit.plugin.gui.BorderStyle;
+import me.anxuiz.settings.bukkit.util.ItemBuilder;
+import me.anxuiz.settings.bukkit.util.InventoryUtil;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Set;
+
+public class SimpleBorderStyle implements BorderStyle {
+
+    private final ItemStack BORDER = ItemBuilder.newItem(Material.STAINED_GLASS_PANE).setDamage((short) 7).setName(ChatColor.GRAY + "#").createItem();
+
+    public SimpleBorderStyle() {
+    }
+
+    public void populateTop(Inventory inventory) {
+        for (int i = 0; i < 9; i++) {
+            InventoryUtil.setItem(this.BORDER, inventory, i, 0, true);
+        }
+    }
+
+    public void populateBottom(Inventory inventory) {
+        for (int j = 0; j < inventory.getSize() / 9; j++) {
+            for (int i = 0; i < 9; i++) {
+                if (j == (inventory.getSize() / 9) - 1) {
+                    InventoryUtil.setItem(this.BORDER, inventory, i, (inventory.getSize()  / 9) - 1, true);
+                }
+            }
+        }
+    }
+
+    public void populateLeft(Inventory inventory) {
+        for (int j = 0; j < inventory.getSize() / 9; j++) {
+            for (int i = 0; i < 9; i++) {
+                if (i == 0) {
+                    InventoryUtil.setItem(this.BORDER, inventory, 0, j, true);
+
+                }
+            }
+        }
+    }
+
+    public void populateRight(Inventory inventory) {
+        for (int j = 0; j < inventory.getSize() / 9; j++) {
+            for (int i = 0; i < 9; i++) {
+                InventoryUtil.setItem(this.BORDER, inventory, 8, j, true);
+
+            }
+        }
+    }
+
+
+
+    public Set<ItemStack> getBoarderIcons() {
+        return Sets.newHashSet(this.BORDER /* Put other boarders in here */);
+    }
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/simple/SimpleInventoryFactory.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/simple/SimpleInventoryFactory.java
@@ -1,0 +1,12 @@
+package me.anxuiz.settings.bukkit.plugin.gui.base.simple;
+
+import me.anxuiz.settings.bukkit.plugin.gui.InventoryStyle;
+import me.anxuiz.settings.bukkit.plugin.gui.base.factory.InventoryStyleFactory;
+import org.bukkit.entity.Player;
+
+public class SimpleInventoryFactory implements InventoryStyleFactory {
+
+    public InventoryStyle createStyle(Player player) {
+        return new SimpleInventoryStyle(player);
+    }
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/simple/SimpleInventoryStyle.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/plugin/gui/base/simple/SimpleInventoryStyle.java
@@ -1,0 +1,25 @@
+package me.anxuiz.settings.bukkit.plugin.gui.base.simple;
+
+import me.anxuiz.settings.Setting;
+import me.anxuiz.settings.bukkit.plugin.SettingsCommand;
+import me.anxuiz.settings.bukkit.plugin.gui.InventoryStyle;
+import me.anxuiz.settings.bukkit.util.IconUtil;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+import javax.annotation.Nonnull;
+
+public class SimpleInventoryStyle implements InventoryStyle {
+
+    private Player player;
+
+    public SimpleInventoryStyle(@Nonnull Player player) {
+        this.player = player;
+    }
+
+    public void populateSlots(Inventory inventory) {
+        for (Setting setting : SettingsCommand.getSortedPlayerSettings(this.player)) {
+            inventory.addItem(IconUtil.makeIcon(setting, this.player, inventory));
+        }
+    }
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/util/IconUtil.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/util/IconUtil.java
@@ -1,0 +1,57 @@
+package me.anxuiz.settings.bukkit.util;
+
+import me.anxuiz.settings.Setting;
+import me.anxuiz.settings.SettingManager;
+import me.anxuiz.settings.Toggleable;
+import me.anxuiz.settings.bukkit.PlayerSettings;
+import me.anxuiz.settings.bukkit.plugin.BukkitSetting;
+import me.anxuiz.settings.bukkit.plugin.Commands;
+import me.anxuiz.settings.bukkit.plugin.Permissions;
+import me.anxuiz.settings.bukkit.plugin.gui.Clickable;
+import org.bukkit.ChatColor;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Collections;
+
+public class IconUtil {
+
+    private IconUtil() {}
+
+    public static ItemStack makeIcon(final Setting setting, final Player player, final Inventory inventory) {
+        if (setting instanceof BukkitSetting) {
+            BukkitSetting bukkitSetting = (BukkitSetting) setting;
+            ItemStack icon = new ItemBuilder(bukkitSetting.getIcon())
+                    .setName(ChatColor.YELLOW + setting.getName())
+                    .addLore(ChatColor.GREEN + "Current Value: " + ChatColor.RESET + setting.getType().print(PlayerSettings.getManager(player).getValue(setting)))
+                    .addLore(ChatColor.AQUA + "Default Value: " + ChatColor.RESET + setting.getType().print(setting.getDefaultValue()))
+                    .addLore(ChatColor.YELLOW + "Summary: " + ChatColor.RESET + setting.getSummary())
+                    .addLore(ChatColor.RED + "" + ChatColor.BOLD + setting.getDescription())
+                    .addLore(ChatColor.YELLOW + "" + ChatColor.ITALIC + "Click to cycle values!")
+                    .createItem();
+            // Each item has its own click handler:
+            return new Clickable(inventory, Collections.singletonList(icon)) {
+                @Override
+                public void click(InventoryClickEvent event) {
+                    Player player = event.getActor();
+                    if (Permissions.hasViewPermission(player, setting) && Permissions.hasSetPermission(player, setting)) {
+                        // Update setting
+                        SettingManager manager = PlayerSettings.getManager(player);
+                        manager.setValue(setting, setting.getType() instanceof Toggleable ? ((Toggleable) setting.getType()).getNextState(manager.getValue(setting)) : manager.getValue(setting));
+                        Commands.sendSettingValue(player, manager, setting);
+                        // Add item to inventory
+                        event.getInventory().setItem(event.getSlot(), makeIcon(setting, player, inventory));
+                        player.playSound(player.getLocation(), Sound.BLOCK_LEVER_CLICK, 1, 1);
+                        // Unregister old listener ready for new item listener
+                        this.unregister();
+                    } else player.sendMessage(Commands.NO_PERMISSION);
+                }
+            }.getItemStacks().get(0);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/me/anxuiz/settings/bukkit/util/InventoryUtil.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/util/InventoryUtil.java
@@ -1,0 +1,23 @@
+package me.anxuiz.settings.bukkit.util;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+public class InventoryUtil {
+
+    private InventoryUtil() {}
+
+    public static boolean setItem(ItemStack itemStack, Inventory inventory, int i, int j, boolean force) {
+        if ((inventory.getItem(locationToLinearSlot(i,j)) != null && force) || inventory.getItem(locationToLinearSlot(i,j)) == null) {
+            inventory.setItem(locationToLinearSlot(i,j), itemStack);
+            return true;
+        }
+        return false;
+    }
+
+    public static int locationToLinearSlot(int i, int j) {
+        return j * 9 + i;
+    }
+
+}
+

--- a/src/main/java/me/anxuiz/settings/bukkit/util/ItemBuilder.java
+++ b/src/main/java/me/anxuiz/settings/bukkit/util/ItemBuilder.java
@@ -1,0 +1,98 @@
+package me.anxuiz.settings.bukkit.util;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+import java.util.Map;
+
+public class ItemBuilder {
+
+    private ItemStack itemStack;
+    private Material material;
+    private int amount = 1;
+    private short damage = 0;
+    private String name;
+    private List<String> lore = Lists.newArrayList();
+    private Map<Enchantment, Integer> enchantments = Maps.newHashMap();
+
+    public ItemBuilder(Material material) {
+        this.material = material;
+    }
+
+    public ItemBuilder(ItemStack itemStack) {
+        this.itemStack = itemStack;
+    }
+
+    public ItemBuilder setMaterial(Material material) {
+        this.material = material;
+        return this;
+    }
+
+    public ItemBuilder setDamage(short damage) {
+        this.damage = damage;
+        return this;
+    }
+
+    public ItemBuilder setAmount(int amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public ItemBuilder setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public ItemBuilder setLore(List<String> lore) {
+        this.lore = lore;
+        return this;
+    }
+
+    public ItemBuilder addLore(String lore) {
+        this.lore.add(lore);
+        return this;
+    }
+
+    public ItemBuilder addLore(String... lore) {
+        for (String string : lore)
+            this.lore.add(string);
+        return this;
+    }
+
+    public ItemBuilder setEnchantments(Map<Enchantment, Integer> enchantments) {
+        this.enchantments = enchantments;
+        return this;
+    }
+
+    public ItemBuilder addEnchantment(Enchantment enchantment, int value) {
+        this.enchantments.put(enchantment, value);
+        return this;
+    }
+
+    public ItemStack createItem() {
+        if (itemStack == null)
+            this.itemStack = new ItemStack(this.material, this.amount, this.damage);
+        ItemMeta itemMeta = this.itemStack.getItemMeta();
+        if (this.name != null)
+            itemMeta.setDisplayName(this.name);
+        if (this.lore != null)
+            itemMeta.setLore(this.lore);
+        if (this.enchantments != null) {
+            for (Enchantment enchantment : this.enchantments.keySet()) {
+                itemMeta.addEnchant(enchantment, this.enchantments.get(enchantment), true);
+            }
+        }
+        this.itemStack.setItemMeta(itemMeta);
+        return this.itemStack;
+    }
+
+    public static ItemBuilder newItem(Material material) {
+        return new ItemBuilder(material);
+    }
+
+}


### PR DESCRIPTION
This is a re write of my old PR, which should address alot of the old issue.

Firstly, the GUI looks the same,
![](http://i.imgur.com/0zkI97p.png)
However, I have now made it that you can style the inventory how you like it, whilst also keeping the code structured. Now to build a settings menu for any player, you must specify which `BorderStyle` and `InventoryStyle` it should use.

`BorderStyle` This style lets you define each part of the border - that is top, bottom, left and right. This enables you to completely customise how you would like to see it. If you like you could have no borders; borders of all the same item; a border that only has items left and right or a border that has a different items in it. To ensure that all of these items get registered and listened for, you must return a list of the items you used in the border. (`BorderStyle#getBoarderIcons()`). I have packed a `SimpleBorderStyle` which adds a border with black stained planes on all edges, as well as a `NoBorderStyle` which allows you to specify no border. The `SimpleStyleBorder` is default.

`InventoryStyle` This lets you define how each setting will be inserted into the inventory, by default the `SimpleInventoryStyle` just adds each item into the inventory. This is safe as the populate border methods are called before the settings are populated, so the settings will just appeal in order next to each other. This gives you the freedom to to specifically choose which slots you may want the settings to go.

There is now also a new `Setting` type, the `BukkitSetting`. This was implemented so you can specify a `ItemStack` that the setting has associated with and appears in the GUI. If you wish the setting to stay hidden, you can define the setting as a `SimpleSetting` as the GUI will ignore it. It is also worth to note that the GUI will only pay attention to settings that implement `Toggleable` as they are the only things that are easy to edit in an inventory.

Each style must have it's own `StyleFactory` this is so an instance of the style can be created for the GUI builder so it can access the methods to populate the inventory. To note, I was originally going to skip a factory and pass in the class into the build method using `Class<? extend BorderStyle>` and use reflection from there, however I decided it was best to avoid that, unless you disagree

Regarding how items are registers and listened. Each inventory will have it's own set of `Listeners`, wrapped in a `Clickable` class. A typical GUI will have a single listener for all border paces and one for each setting. This means that there are multiple `Listeners` in each inventory, which is a compromise I took to make the code nicer and redable.